### PR TITLE
Do not update parallax container if the DOM ref is missing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -270,6 +270,7 @@ var _initialiseProps = function _initialiseProps() {
     };
 
     this.update = function () {
+        if (!_this4.refs.container) return;
         _this4.height = _this4.refs.container.clientHeight;
 
         if (_this4.props.scrolling) _this4.scrollTop = _this4.refs.container.scrollTop;else _this4.refs.container.scrollTop = _this4.scrollTop = _this4.offset * _this4.height;

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ export default class extends React.Component {
     }
 
     update = () => {
+        if (!this.refs.container) return;
         this.height = this.refs.container.clientHeight
 
         if (this.props.scrolling) this.scrollTop = this.refs.container.scrollTop


### PR DESCRIPTION
Quick patch for issue Getting TypeError: Cannot read property 'clientHeight' of undefined #5