### PR TITLE
Support old vendors css transform properties

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-    value: true
+  value: true
 });
 
 var _class2, _temp;
@@ -33,268 +33,284 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _class = function (_React$Component) {
-    _inherits(_class, _React$Component);
+  _inherits(_class, _React$Component);
 
-    function _class(props) {
-        _classCallCheck(this, _class);
+  function _class(props) {
+    _classCallCheck(this, _class);
 
-        var _this = _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).call(this, props));
+    var _this = _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).call(this, props));
 
-        _initialiseProps.call(_this);
+    _initialiseProps.call(_this);
 
-        _this.state = { ready: false };
-        _this.layers = [];
-        _this.height = 0;
-        _this.scrollTop = 0;
-        _this.offset = 0;
-        _this.busy = false;
-        return _this;
+    _this.state = { ready: false };
+    _this.layers = [];
+    _this.height = 0;
+    _this.scrollTop = 0;
+    _this.offset = 0;
+    _this.busy = false;
+    return _this;
+  }
+
+  _createClass(_class, [{
+    key: 'scrollTo',
+    value: function scrollTo(offset) {
+      this.scrollStop();
+      this.offset = offset;
+      var target = this.refs.container;
+      this.animatedScroll = new _reactDom2.default.Value(target.scrollTop);
+      this.animatedScroll.addListener(function (_ref) {
+        var value = _ref.value;
+        return target.scrollTop = value;
+      });
+      this.props.effect(this.animatedScroll, offset * this.height).start();
     }
+  }, {
+    key: 'getChildContext',
+    value: function getChildContext() {
+      return { parallax: this };
+    }
+  }, {
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      window.addEventListener('resize', this.updateRaf, false);
+      this.update();
+      this.setState({ ready: true });
+    }
+  }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      window.removeEventListener('resize', this.updateRaf, false);
+    }
+  }, {
+    key: 'componentDidUpdate',
+    value: function componentDidUpdate() {
+      this.update();
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _props = this.props,
+          style = _props.style,
+          innerStyle = _props.innerStyle,
+          pages = _props.pages,
+          className = _props.className,
+          scrolling = _props.scrolling,
+          children = _props.children;
 
-    _createClass(_class, [{
-        key: 'scrollTo',
-        value: function scrollTo(offset) {
-            this.scrollStop();
-            this.offset = offset;
-            var target = this.refs.container;
-            this.animatedScroll = new _reactDom2.default.Value(target.scrollTop);
-            this.animatedScroll.addListener(function (_ref) {
-                var value = _ref.value;
-                return target.scrollTop = value;
-            });
-            this.props.effect(this.animatedScroll, offset * this.height).start();
-        }
-    }, {
-        key: 'getChildContext',
-        value: function getChildContext() {
-            return { parallax: this };
-        }
-    }, {
-        key: 'componentDidMount',
-        value: function componentDidMount() {
-            window.addEventListener('resize', this.updateRaf, false);
-            this.update();
-            this.setState({ ready: true });
-        }
-    }, {
-        key: 'componentWillUnmount',
-        value: function componentWillUnmount() {
-            window.removeEventListener('resize', this.updateRaf, false);
-        }
-    }, {
-        key: 'componentDidUpdate',
-        value: function componentDidUpdate() {
-            this.update();
-        }
-    }, {
-        key: 'render',
-        value: function render() {
-            var _props = this.props,
-                style = _props.style,
-                innerStyle = _props.innerStyle,
-                pages = _props.pages,
-                className = _props.className,
-                scrolling = _props.scrolling,
-                children = _props.children;
+      return _react2.default.createElement(
+        'div',
+        {
+          ref: 'container',
+          onScroll: this.onScroll,
+          onWheel: scrolling && this.scrollStop,
+          onTouchStart: scrolling && this.scrollStop,
+          style: _extends({
+            position: 'absolute',
+            width: '100%',
+            height: '100%',
+            overflow: scrolling ? 'scroll' : 'hidden',
+            overflowX: 'hidden',
+            WebkitOverflowScrolling: 'touch',
+            WebkitTransform: 'translate(0, 0)',
+            MsTransform: 'translate(0, 0)',
+            transform: 'translate3d(0, 0, 0)'
+          }, style),
+          className: className
+        },
+        this.state.ready && _react2.default.createElement(
+          'div',
+          {
+            ref: 'content',
+            style: _extends({
+              position: 'absolute',
+              width: '100%',
+              WebkitTransform: 'translate(0,0)',
+              MsTransform: 'translate(0,0)',
+              transform: 'translate3d(0, 0, 0)',
+              overflow: 'hidden',
+              height: this.height * pages
+            }, innerStyle)
+          },
+          children
+        )
+      );
+    }
+  }]);
 
-            return _react2.default.createElement(
-                'div',
-                {
-                    ref: 'container',
-                    onScroll: this.onScroll,
-                    onWheel: scrolling && this.scrollStop,
-                    onTouchStart: scrolling && this.scrollStop,
-                    style: _extends({
-                        position: 'absolute',
-                        width: '100%',
-                        height: '100%',
-                        overflow: scrolling ? 'scroll' : 'hidden',
-                        overflowX: 'hidden',
-                        WebkitOverflowScrolling: 'touch',
-                        transform: 'translate3d(0, 0, 0)'
-                    }, style),
-                    className: className },
-                this.state.ready && _react2.default.createElement(
-                    'div',
-                    {
-                        ref: 'content',
-                        style: _extends({
-                            position: 'absolute',
-                            width: '100%',
-                            transform: 'translate3d(0, 0, 0)',
-                            overflow: 'hidden',
-                            height: this.height * pages
-                        }, innerStyle) },
-                    children
-                )
-            );
-        }
-    }]);
-
-    return _class;
+  return _class;
 }(_react2.default.Component);
 
 _class.propTypes = {
-    pages: _propTypes2.default.number.isRequired,
-    effect: _propTypes2.default.func,
-    scrolling: _propTypes2.default.bool
+  pages: _propTypes2.default.number.isRequired,
+  effect: _propTypes2.default.func,
+  scrolling: _propTypes2.default.bool
 };
 _class.defaultProps = {
-    effect: function effect(animation, toValue) {
-        return _reactDom2.default.spring(animation, { toValue: toValue });
-    },
-    scrolling: true
+  effect: function effect(animation, toValue) {
+    return _reactDom2.default.spring(animation, { toValue: toValue });
+  },
+  scrolling: true
 };
 _class.childContextTypes = { parallax: _propTypes2.default.object };
 _class.Layer = (_temp = _class2 = function (_React$Component2) {
-    _inherits(_class2, _React$Component2);
+  _inherits(_class2, _React$Component2);
 
-    function _class2(props, context) {
-        _classCallCheck(this, _class2);
+  function _class2(props, context) {
+    _classCallCheck(this, _class2);
 
-        var _this2 = _possibleConstructorReturn(this, (_class2.__proto__ || Object.getPrototypeOf(_class2)).call(this, props, context));
+    var _this2 = _possibleConstructorReturn(this, (_class2.__proto__ || Object.getPrototypeOf(_class2)).call(this, props, context));
 
-        var parallax = context.parallax;
-        var targetScroll = Math.floor(props.offset) * parallax.height;
-        var offset = parallax.height * props.offset + targetScroll * props.speed;
-        var toValue = parseFloat(-(parallax.scrollTop * props.speed) + offset);
-        _this2.animatedTranslate = new _reactDom2.default.Value(toValue);
-        var height = parallax.height * props.factor;
-        _this2.animatedHeight = new _reactDom2.default.Value(height);
-        return _this2;
+    var parallax = context.parallax;
+    var targetScroll = Math.floor(props.offset) * parallax.height;
+    var offset = parallax.height * props.offset + targetScroll * props.speed;
+    var toValue = parseFloat(-(parallax.scrollTop * props.speed) + offset);
+    _this2.animatedTranslate = new _reactDom2.default.Value(toValue);
+    var height = parallax.height * props.factor;
+    _this2.animatedHeight = new _reactDom2.default.Value(height);
+    return _this2;
+  }
+
+  _createClass(_class2, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      var parent = this.context.parallax;
+      if (parent) {
+        parent.layers = parent.layers.concat(this);
+        parent.update();
+      }
     }
+  }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      var _this3 = this;
 
-    _createClass(_class2, [{
-        key: 'componentDidMount',
-        value: function componentDidMount() {
-            var parent = this.context.parallax;
-            if (parent) {
-                parent.layers = parent.layers.concat(this);
-                parent.update();
-            }
-        }
-    }, {
-        key: 'componentWillUnmount',
-        value: function componentWillUnmount() {
-            var _this3 = this;
+      var parent = this.context.parallax;
+      if (parent) {
+        parent.layers = parent.layers.filter(function (layer) {
+          return layer !== _this3;
+        });
+        parent.update();
+      }
+    }
+  }, {
+    key: 'setPosition',
+    value: function setPosition(height, scrollTop) {
+      var immediate = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
 
-            var parent = this.context.parallax;
-            if (parent) {
-                parent.layers = parent.layers.filter(function (layer) {
-                    return layer !== _this3;
-                });
-                parent.update();
-            }
-        }
-    }, {
-        key: 'setPosition',
-        value: function setPosition(height, scrollTop) {
-            var immediate = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+      var targetScroll = Math.floor(this.props.offset) * height;
+      var offset = height * this.props.offset + targetScroll * this.props.speed;
+      var toValue = parseFloat(-(scrollTop * this.props.speed) + offset);
+      if (!immediate) this.context.parallax.props.effect(this.animatedTranslate, toValue).start();else this.animatedTranslate.setValue(toValue);
+    }
+  }, {
+    key: 'setHeight',
+    value: function setHeight(height) {
+      var immediate = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 
-            var targetScroll = Math.floor(this.props.offset) * height;
-            var offset = height * this.props.offset + targetScroll * this.props.speed;
-            var toValue = parseFloat(-(scrollTop * this.props.speed) + offset);
-            if (!immediate) this.context.parallax.props.effect(this.animatedTranslate, toValue).start();else this.animatedTranslate.setValue(toValue);
-        }
-    }, {
-        key: 'setHeight',
-        value: function setHeight(height) {
-            var immediate = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+      var toValue = parseFloat(height * this.props.factor);
+      if (!immediate) this.context.parallax.props.effect(this.animatedHeight, toValue).start();else this.animatedHeight.setValue(toValue);
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _props2 = this.props,
+          style = _props2.style,
+          children = _props2.children,
+          offset = _props2.offset,
+          speed = _props2.speed,
+          factor = _props2.factor,
+          className = _props2.className,
+          props = _objectWithoutProperties(_props2, ['style', 'children', 'offset', 'speed', 'factor', 'className']);
 
-            var toValue = parseFloat(height * this.props.factor);
-            if (!immediate) this.context.parallax.props.effect(this.animatedHeight, toValue).start();else this.animatedHeight.setValue(toValue);
-        }
-    }, {
-        key: 'render',
-        value: function render() {
-            var _props2 = this.props,
-                style = _props2.style,
-                children = _props2.children,
-                offset = _props2.offset,
-                speed = _props2.speed,
-                factor = _props2.factor,
-                className = _props2.className,
-                props = _objectWithoutProperties(_props2, ['style', 'children', 'offset', 'speed', 'factor', 'className']);
+      var vendorTranslate = 'translate(' + this.animatedTranslate.interpolate({
+        inputRange: [0, 1],
+        outputRange: ['0,0px', '0,1px']
+      })._parent._offset + 'px,' + this.animatedTranslate.interpolate({
+        inputRange: [0, 1],
+        outputRange: ['0,0px', '0,1px']
+      })._parent._value + 'px)';
+      return _react2.default.createElement(
+        _reactDom2.default.div,
+        _extends({}, props, {
+          ref: 'layer',
+          className: className,
+          style: _extends({
+            position: 'absolute',
+            backgroundSize: 'auto',
+            backgroundRepeat: 'no-repeat',
+            willChange: 'transform',
+            width: '100%',
+            height: this.animatedHeight,
+            WebkitTransform: 'translate(0, 0)',
+            MsTransform: 'translate(0, 0)',
+            transform: [{
+              translate3d: this.animatedTranslate.interpolate({
+                inputRange: [0, 1],
+                outputRange: ['0,0px,0', '0,1px,0']
+              })
+            }]
+          }, style)
+        }),
+        children
+      );
+    }
+  }]);
 
-            return _react2.default.createElement(
-                _reactDom2.default.div,
-                _extends({}, props, {
-                    ref: 'layer',
-                    className: className,
-                    style: _extends({
-                        position: 'absolute',
-                        backgroundSize: 'auto',
-                        backgroundRepeat: 'no-repeat',
-                        willChange: 'transform',
-                        width: '100%',
-                        height: this.animatedHeight,
-                        transform: [{
-                            translate3d: this.animatedTranslate.interpolate({
-                                inputRange: [0, 1],
-                                outputRange: ['0,0px,0', '0,1px,0']
-                            })
-                        }]
-                    }, style) }),
-                children
-            );
-        }
-    }]);
-
-    return _class2;
+  return _class2;
 }(_react2.default.Component), _class2.contextTypes = { parallax: _propTypes2.default.object }, _class2.propTypes = {
-    factor: _propTypes2.default.number,
-    offset: _propTypes2.default.number,
-    speed: _propTypes2.default.number
+  factor: _propTypes2.default.number,
+  offset: _propTypes2.default.number,
+  speed: _propTypes2.default.number
 }, _class2.defaultProps = {
-    factor: 1,
-    offset: 0,
-    speed: 0
+  factor: 1,
+  offset: 0,
+  speed: 0
 }, _temp);
 
 var _initialiseProps = function _initialiseProps() {
-    var _this4 = this;
+  var _this4 = this;
 
-    this.moveItems = function () {
-        _this4.layers.forEach(function (layer) {
-            return layer.setPosition(_this4.height, _this4.scrollTop);
-        });
-        _this4.busy = false;
-    };
+  this.moveItems = function () {
+    _this4.layers.forEach(function (layer) {
+      return layer.setPosition(_this4.height, _this4.scrollTop);
+    });
+    _this4.busy = false;
+  };
 
-    this.scrollerRaf = function () {
-        return requestAnimationFrame(_this4.moveItems);
-    };
+  this.scrollerRaf = function () {
+    return requestAnimationFrame(_this4.moveItems);
+  };
 
-    this.onScroll = function (event) {
-        if (!_this4.busy) {
-            _this4.busy = true;
-            _this4.scrollerRaf();
-            _this4.scrollTop = event.target.scrollTop;
-        }
-    };
+  this.onScroll = function (event) {
+    if (!_this4.busy) {
+      _this4.busy = true;
+      _this4.scrollerRaf();
+      _this4.scrollTop = event.target.scrollTop;
+    }
+  };
 
-    this.update = function () {
-        if (!_this4.refs.container) return;
-        _this4.height = _this4.refs.container.clientHeight;
+  this.update = function () {
+    if (!_this4.refs.container) return;
+    _this4.height = _this4.refs.container.clientHeight;
 
-        if (_this4.props.scrolling) _this4.scrollTop = _this4.refs.container.scrollTop;else _this4.refs.container.scrollTop = _this4.scrollTop = _this4.offset * _this4.height;
+    if (_this4.props.scrolling) _this4.scrollTop = _this4.refs.container.scrollTop;else _this4.refs.container.scrollTop = _this4.scrollTop = _this4.offset * _this4.height;
 
-        if (_this4.refs.content) _this4.refs.content.style.height = _this4.height * _this4.props.pages + 'px';
-        _this4.layers.forEach(function (layer) {
-            layer.setHeight(_this4.height, true);
-            layer.setPosition(_this4.height, _this4.scrollTop, true);
-        });
-    };
+    if (_this4.refs.content) _this4.refs.content.style.height = _this4.height * _this4.props.pages + 'px';
+    _this4.layers.forEach(function (layer) {
+      layer.setHeight(_this4.height, true);
+      layer.setPosition(_this4.height, _this4.scrollTop, true);
+    });
+  };
 
-    this.updateRaf = function () {
-        requestAnimationFrame(_this4.update);
-        // Some browsers don't fire on maximize
-        setTimeout(_this4.update, 150);
-    };
+  this.updateRaf = function () {
+    requestAnimationFrame(_this4.update);
+    // Some browsers don't fire on maximize
+    setTimeout(_this4.update, 150);
+  };
 
-    this.scrollStop = function (event) {
-        return _this4.animatedScroll && _this4.animatedScroll.stopAnimation();
-    };
+  this.scrollStop = function (event) {
+    return _this4.animatedScroll && _this4.animatedScroll.stopAnimation();
+  };
 };
 
 exports.default = _class;

--- a/dist/index.js
+++ b/dist/index.js
@@ -241,8 +241,8 @@ _class.Layer = (_temp = _class2 = function (_React$Component2) {
             willChange: 'transform',
             width: '100%',
             height: this.animatedHeight,
-            WebkitTransform: 'translate(0, 0)',
-            MsTransform: 'translate(0, 0)',
+            WebkitTransform: vendorTranslate,
+            MsTransform: vendorTranslate,
             transform: [{
               translate3d: this.animatedTranslate.interpolate({
                 inputRange: [0, 1],

--- a/index.js
+++ b/index.js
@@ -1,212 +1,262 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import Animated from 'animated/lib/targets/react-dom'
+import React from 'react';
+import PropTypes from 'prop-types';
+import Animated from 'animated/lib/targets/react-dom';
 
 export default class extends React.Component {
+  static propTypes = {
+    pages: PropTypes.number.isRequired,
+    effect: PropTypes.func,
+    scrolling: PropTypes.bool,
+  };
+  static defaultProps = {
+    effect: (animation, toValue) => Animated.spring(animation, { toValue }),
+    scrolling: true,
+  };
+  static childContextTypes = { parallax: PropTypes.object };
+
+  constructor(props) {
+    super(props);
+    this.state = { ready: false };
+    this.layers = [];
+    this.height = 0;
+    this.scrollTop = 0;
+    this.offset = 0;
+    this.busy = false;
+  }
+
+  moveItems = () => {
+    this.layers.forEach(layer =>
+      layer.setPosition(this.height, this.scrollTop),
+    );
+    this.busy = false;
+  };
+
+  scrollerRaf = () => requestAnimationFrame(this.moveItems);
+
+  onScroll = event => {
+    if (!this.busy) {
+      this.busy = true;
+      this.scrollerRaf();
+      this.scrollTop = event.target.scrollTop;
+    }
+  };
+
+  update = () => {
+    if (!this.refs.container) return;
+    this.height = this.refs.container.clientHeight;
+
+    if (this.props.scrolling) this.scrollTop = this.refs.container.scrollTop;
+    else
+      this.refs.container.scrollTop = this.scrollTop =
+        this.offset * this.height;
+
+    if (this.refs.content)
+      this.refs.content.style.height = `${this.height * this.props.pages}px`;
+    this.layers.forEach(layer => {
+      layer.setHeight(this.height, true);
+      layer.setPosition(this.height, this.scrollTop, true);
+    });
+  };
+
+  updateRaf = () => {
+    requestAnimationFrame(this.update);
+    // Some browsers don't fire on maximize
+    setTimeout(this.update, 150);
+  };
+
+  scrollStop = event =>
+    this.animatedScroll && this.animatedScroll.stopAnimation();
+
+  scrollTo(offset) {
+    this.scrollStop();
+    this.offset = offset;
+    const target = this.refs.container;
+    this.animatedScroll = new Animated.Value(target.scrollTop);
+    this.animatedScroll.addListener(({ value }) => (target.scrollTop = value));
+    this.props.effect(this.animatedScroll, offset * this.height).start();
+  }
+
+  getChildContext() {
+    return { parallax: this };
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this.updateRaf, false);
+    this.update();
+    this.setState({ ready: true });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateRaf, false);
+  }
+
+  componentDidUpdate() {
+    this.update();
+  }
+
+  render() {
+    const {
+      style,
+      innerStyle,
+      pages,
+      className,
+      scrolling,
+      children,
+    } = this.props;
+    return (
+      <div
+        ref="container"
+        onScroll={this.onScroll}
+        onWheel={scrolling && this.scrollStop}
+        onTouchStart={scrolling && this.scrollStop}
+        style={{
+          position: 'absolute',
+          width: '100%',
+          height: '100%',
+          overflow: scrolling ? 'scroll' : 'hidden',
+          overflowX: 'hidden',
+          WebkitOverflowScrolling: 'touch',
+          WebkitTransform: 'translate(0, 0)',
+          MsTransform: 'translate(0, 0)',
+          transform: 'translate3d(0, 0, 0)',
+          ...style,
+        }}
+        className={className}
+      >
+        {this.state.ready && (
+          <div
+            ref="content"
+            style={{
+              position: 'absolute',
+              width: '100%',
+              WebkitTransform: 'translate(0,0)',
+              MsTransform: 'translate(0,0)',
+              transform: 'translate3d(0, 0, 0)',
+              overflow: 'hidden',
+              height: this.height * pages,
+              ...innerStyle,
+            }}
+          >
+            {children}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  static Layer = class extends React.Component {
+    static contextTypes = { parallax: PropTypes.object };
     static propTypes = {
-        pages: PropTypes.number.isRequired,
-        effect: PropTypes.func,
-        scrolling: PropTypes.bool
-    }
+      factor: PropTypes.number,
+      offset: PropTypes.number,
+      speed: PropTypes.number,
+    };
     static defaultProps = {
-        effect: (animation, toValue) => Animated.spring(animation, { toValue }),
-        scrolling: true
-    }
-    static childContextTypes = { parallax: PropTypes.object }
+      factor: 1,
+      offset: 0,
+      speed: 0,
+    };
 
-    constructor(props) {
-        super(props)
-        this.state = { ready: false }
-        this.layers = []
-        this.height = 0
-        this.scrollTop = 0
-        this.offset = 0
-        this.busy = false
-    }
-
-    moveItems = () => {
-        this.layers.forEach(layer => layer.setPosition(this.height, this.scrollTop))
-        this.busy = false
-    }
-
-    scrollerRaf = () => requestAnimationFrame(this.moveItems)
-
-    onScroll = event => {
-        if (!this.busy) {
-            this.busy = true
-            this.scrollerRaf()
-            this.scrollTop = event.target.scrollTop
-        }
-    }
-
-    update = () => {
-        if (!this.refs.container) return;
-        this.height = this.refs.container.clientHeight
-
-        if (this.props.scrolling) this.scrollTop = this.refs.container.scrollTop
-        else this.refs.container.scrollTop = (this.scrollTop = this.offset * this.height)
-
-        if (this.refs.content) this.refs.content.style.height = `${this.height * this.props.pages}px`
-        this.layers.forEach(layer => {
-            layer.setHeight(this.height, true)
-            layer.setPosition(this.height, this.scrollTop, true)
-        })
-    }
-
-    updateRaf = () => {
-        requestAnimationFrame(this.update)
-        // Some browsers don't fire on maximize
-        setTimeout(this.update, 150)
-    }
-
-    scrollStop = event => this.animatedScroll && this.animatedScroll.stopAnimation()
-
-    scrollTo(offset) {
-        this.scrollStop()
-        this.offset = offset
-        const target = this.refs.container
-        this.animatedScroll = new Animated.Value(target.scrollTop)
-        this.animatedScroll.addListener(({ value }) => target.scrollTop = value)
-        this.props.effect(this.animatedScroll, offset * this.height).start()
-    }
-
-    getChildContext() {
-        return { parallax: this }
+    constructor(props, context) {
+      super(props, context);
+      const parallax = context.parallax;
+      const targetScroll = Math.floor(props.offset) * parallax.height;
+      const offset =
+        parallax.height * props.offset + targetScroll * props.speed;
+      const toValue = parseFloat(-(parallax.scrollTop * props.speed) + offset);
+      this.animatedTranslate = new Animated.Value(toValue);
+      const height = parallax.height * props.factor;
+      this.animatedHeight = new Animated.Value(height);
     }
 
     componentDidMount() {
-        window.addEventListener('resize', this.updateRaf, false)
-        this.update()
-        this.setState({ ready: true })
+      const parent = this.context.parallax;
+      if (parent) {
+        parent.layers = parent.layers.concat(this);
+        parent.update();
+      }
     }
 
     componentWillUnmount() {
-        window.removeEventListener('resize', this.updateRaf, false)
+      const parent = this.context.parallax;
+      if (parent) {
+        parent.layers = parent.layers.filter(layer => layer !== this);
+        parent.update();
+      }
     }
 
-    componentDidUpdate() {
-        this.update()
+    setPosition(height, scrollTop, immediate = false) {
+      const targetScroll = Math.floor(this.props.offset) * height;
+      const offset =
+        height * this.props.offset + targetScroll * this.props.speed;
+      const toValue = parseFloat(-(scrollTop * this.props.speed) + offset);
+      if (!immediate)
+        this.context.parallax.props
+          .effect(this.animatedTranslate, toValue)
+          .start();
+      else this.animatedTranslate.setValue(toValue);
+    }
+
+    setHeight(height, immediate = false) {
+      const toValue = parseFloat(height * this.props.factor);
+      if (!immediate)
+        this.context.parallax.props
+          .effect(this.animatedHeight, toValue)
+          .start();
+      else this.animatedHeight.setValue(toValue);
     }
 
     render() {
-        const { style, innerStyle, pages, className, scrolling, children } = this.props
-        return (
-            <div
-                ref="container"
-                onScroll={this.onScroll}
-                onWheel={scrolling && this.scrollStop}
-                onTouchStart={scrolling && this.scrollStop}
-                style={{
-                    position: 'absolute',
-                    width: '100%',
-                    height: '100%',
-                    overflow: scrolling ? 'scroll' : 'hidden',
-                    overflowX: 'hidden',
-                    WebkitOverflowScrolling: 'touch',
-                    transform: 'translate3d(0, 0, 0)',
-                    ...style
-                }}
-                className={className}>
-
-                {this.state.ready &&
-                    <div
-                        ref="content"
-                        style={{
-                            position: 'absolute',
-                            width: '100%',
-                            transform: 'translate3d(0, 0, 0)',
-                            overflow: 'hidden',
-                            height: this.height * pages,
-                            ...innerStyle
-                        }}>
-                        {children}
-                    </div>}
-
-            </div>
-        )
+      const {
+        style,
+        children,
+        offset,
+        speed,
+        factor,
+        className,
+        ...props
+      } = this.props;
+      
+      const vendorTranslate =
+        'translate(' +
+        this.animatedTranslate.interpolate({
+          inputRange: [0, 1],
+          outputRange: ['0,0px', '0,1px'],
+        })._parent._offset +
+        'px,' +
+        this.animatedTranslate.interpolate({
+          inputRange: [0, 1],
+          outputRange: ['0,0px', '0,1px'],
+        })._parent._value +
+        'px)';
+      return (
+        <Animated.div
+          {...props}
+          ref="layer"
+          className={className}
+          style={{
+            position: 'absolute',
+            backgroundSize: 'auto',
+            backgroundRepeat: 'no-repeat',
+            willChange: 'transform',
+            width: '100%',
+            height: this.animatedHeight,
+            WebkitTransform: 'translate(0, 0)',
+            MsTransform: 'translate(0, 0)',
+            transform: [
+              {
+                translate3d: this.animatedTranslate.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: ['0,0px,0', '0,1px,0'],
+                }),
+              },
+            ],
+            ...style,
+          }}
+        >
+          {children}
+        </Animated.div>
+      );
     }
-
-    static Layer = class extends React.Component {
-        static contextTypes = { parallax: PropTypes.object }
-        static propTypes = {
-            factor: PropTypes.number,
-            offset: PropTypes.number,
-            speed: PropTypes.number
-        }
-        static defaultProps = {
-            factor: 1,
-            offset: 0,
-            speed: 0
-        }
-
-        constructor(props, context) {
-            super(props, context)
-            const parallax = context.parallax
-            const targetScroll = Math.floor(props.offset) * parallax.height
-            const offset = parallax.height * props.offset + targetScroll * props.speed
-            const toValue = parseFloat(-(parallax.scrollTop * props.speed) + offset)
-            this.animatedTranslate = new Animated.Value(toValue)
-            const height = parallax.height * props.factor
-            this.animatedHeight = new Animated.Value(height)
-        }
-
-        componentDidMount() {
-            const parent = this.context.parallax
-            if (parent) {
-                parent.layers = parent.layers.concat(this)
-                parent.update()
-            }
-        }
-
-        componentWillUnmount() {
-            const parent = this.context.parallax
-            if (parent) {
-                parent.layers = parent.layers.filter(layer => layer !== this)
-                parent.update()
-            }
-        }
-
-        setPosition(height, scrollTop, immediate = false) {
-            const targetScroll = Math.floor(this.props.offset) * height
-            const offset = height * this.props.offset + targetScroll * this.props.speed
-            const toValue = parseFloat(-(scrollTop * this.props.speed) + offset)
-            if (!immediate) this.context.parallax.props.effect(this.animatedTranslate, toValue).start()
-            else this.animatedTranslate.setValue(toValue)
-        }
-
-        setHeight(height, immediate = false) {
-            const toValue = parseFloat(height * this.props.factor)
-            if (!immediate) this.context.parallax.props.effect(this.animatedHeight, toValue).start()
-            else this.animatedHeight.setValue(toValue)
-        }
-
-        render() {
-            const { style, children, offset, speed, factor, className, ...props } = this.props
-            return (
-                <Animated.div
-                    {...props}
-                    ref="layer"
-                    className={className}
-                    style={{
-                        position: 'absolute',
-                        backgroundSize: 'auto',
-                        backgroundRepeat: 'no-repeat',
-                        willChange: 'transform',
-                        width: '100%',
-                        height: this.animatedHeight,
-                        transform: [
-                            {
-                                translate3d: this.animatedTranslate.interpolate({
-                                    inputRange: [0, 1],
-                                    outputRange: ['0,0px,0', '0,1px,0']
-                                })
-                            }
-                        ],
-                        ...style
-                    }}>
-                    {children}
-                </Animated.div>
-            )
-        }
-    }
+  };
 }

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ export default class extends React.Component {
         className,
         ...props
       } = this.props;
-      
+
       const vendorTranslate =
         'translate(' +
         this.animatedTranslate.interpolate({
@@ -241,8 +241,8 @@ export default class extends React.Component {
             willChange: 'transform',
             width: '100%',
             height: this.animatedHeight,
-            WebkitTransform: 'translate(0, 0)',
-            MsTransform: 'translate(0, 0)',
+            WebkitTransform: vendorTranslate,
+            MsTransform: vendorTranslate,
             transform: [
               {
                 translate3d: this.animatedTranslate.interpolate({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-springy-parallax",
-  "version": "1.0.11",
+  "name": "@tadaweb/react-springy-parallax",
+  "version": "1.0.12",
   "description": "composeable springy parallax",
   "main": "dist/index.js",
   "jsnext:main": "index.js",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/drcmda/react-springy-parallax.git"
+    "url": "git+https://github.com/christophediprima/react-springy-parallax.git"
   },
   "keywords": [
     "parallax",


### PR DESCRIPTION
I also used prettier so the code has been formatted but there is not a lot of changes:

```javascript
 const vendorTranslate =
        'translate(' +
        this.animatedTranslate.interpolate({
          inputRange: [0, 1],
          outputRange: ['0,0px', '0,1px'],
        })._parent._offset +
        'px,' +
        this.animatedTranslate.interpolate({
          inputRange: [0, 1],
          outputRange: ['0,0px', '0,1px'],
        })._parent._value +
        'px)';

return (<Animated.div
          {...props}
          ref="layer"
          className={className}
          style={{
            position: 'absolute',
            backgroundSize: 'auto',
            backgroundRepeat: 'no-repeat',
            willChange: 'transform',
            width: '100%',
            height: this.animatedHeight,
            WebkitTransform: vendorTranslate,
            MsTransform: vendorTranslate,
            transform: [
              {
                translate3d: this.animatedTranslate.interpolate({
                  inputRange: [0, 1],
                  outputRange: ['0,0px,0', '0,1px,0'],
                }),
              },
            ],
...

```
